### PR TITLE
Fixes to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,6 @@ BIN_DIR="$HOME/.local/bin"
 
 mkdir -p "$BIN_DIR"
 cd "$BIN_DIR" || exit
-curl -OL https://github.com/oknozor/cocogitto/releases/download/"$VERSION"/"$TAR"
+curl -OL https://github.com/cocogitto/cocogitto/releases/download/"$VERSION"/"$TAR"
 tar xfz $TAR
 cd "$CUR_DIR" || exit

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CUR_DIR=$(pwd)
-VERSION=4.0.1
+VERSION=4.1.0
 TAR="cocogitto-$VERSION-x86_64-unknown-linux-musl.tar.gz"
 BIN_DIR="$HOME/.local/bin"
 


### PR DESCRIPTION
I was getting strange errors in my CI runs using this action, despite what should presumably be the same action (e.g `cog bump --auto`) works just fine locally.

I eventually noticed that...

1. It appears to be pulling from an old repo ([github.com/oknozor/cocogitto](https://github.com/oknozor/cocogitto))
2. It is using an old version (`4.0.1`)