### PR TITLE
feat: enable use of `cog verify` in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,37 +1,50 @@
-name: 'Conventional commit cocogitto action'
-description: 'Check conventional commits compliance and/or automatically release new version'
+---
+name: Conventional commit cocogitto action
+
+description: |
+  Check conventional commits compliance and/or automatically release new version
+
 branding:
-  icon: 'git-commit'
-  color: 'red'
-author: 'Paul Delafosse'
+  icon: git-commit
+  color: red
+
+author: Paul Delafosse
 
 inputs:
   release:
-    description: 'Perform a release with cog bump --auto'
+    description: Perform a release with cog bump --auto
     required: false
     default: 'false'
   check:
-    description: 'Perform a conventional commit check with cog --check'
+    description: Perform a conventional commit check with cog --check
     required: false
     default: 'true'
   check-latest-tag-only:
-    description: 'Check commit history from latest tag to HEAD'
+    description: Check commit history from latest tag to HEAD
     required: false
     default: 'false'
   git-user:
-    description: 'Git user.name configuration'
+    description: Git user.name configuration
     required: false
     default: 'cog-bot'
   git-user-email:
-    description: 'Git user.email configuration'
+    description: Git user.email configuration
     required: false
     default: 'cog@demo.org'
+  verify:
+    description: |-
+      Check an arbitrary input string against the conventional
+      commit specification but do not create any commit.
+    required: false
+    default: 'false'
+
 outputs:
   version:
-    description: "Version released"
+    description: Version released
     value: ${{ steps.cog.outputs.version }}
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - run: echo Installing cocogitto
       shell: bash
@@ -49,11 +62,12 @@ runs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - id: cog
+      shell: bash
       run: |
         ${{ github.action_path }}/cog.sh    \
-        ${{ inputs.check }} \
+        ${{ inputs.check }}                 \
         ${{ inputs.check-latest-tag-only }} \
         ${{ inputs.release }}               \
         ${{ inputs.git-user }}              \
-        ${{ inputs.git-user-email }}
-      shell: bash
+        ${{ inputs.git-user-email }}        \
+        ${{ inputs.verify }}

--- a/cog.sh
+++ b/cog.sh
@@ -2,28 +2,29 @@
 
 set -a
 
-CHECK=$1
-LATEST_TAG_ONLY=$2
-RELEASE=$3
-GIT_USER=$4
-GIT_USER_EMAIL=$5
+CHECK="${1}"
+LATEST_TAG_ONLY="${2}"
+RELEASE="${3}"
+GIT_USER="${4}"
+GIT_USER_EMAIL="${5}"
+VERIFY="${7}"
 
-echo "Setting git user : $GIT_USER"
-git config --global user.name "$GIT_USER"
+echo "Setting git user : ${GIT_USER}"
+git config --global user.name "${GIT_USER}"
 
-echo "Settings git user email $GIT_USER_EMAIL"
-git config --global user.email "$GIT_USER_EMAIL"
+echo "Settings git user email ${GIT_USER_EMAIL}"
+git config --global user.email "${GIT_USER_EMAIL}"
 
 cog --version
 
-if [ "$CHECK" = "true" ]; then
-  if [ "$LATEST_TAG_ONLY" = "true" ]; then
+if [ "${CHECK}" = "true" ]; then
+  if [ "${LATEST_TAG_ONLY}" = "true" ]; then
     if [ "$(git describe --tags --abbrev=0)" ]; then
       message="Checking commits from $(git describe --tags --abbrev=0)"
     else
       message="No tag found checking history from first commit"
     fi
-    echo "$message"
+    echo "${message}"
     cog check --from-latest-tag || exit 1
   else
     echo "Checking all commits"
@@ -31,8 +32,12 @@ if [ "$CHECK" = "true" ]; then
   fi
 fi
 
-if [ "$RELEASE" = "true" ]; then
+if [ "${RELEASE}" = "true" ]; then
   cog bump --auto || exit 1
   VERSION="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
   echo "version=$VERSION" >> $GITHUB_OUTPUT
+fi
+
+if ( echo "${VERIFY}" | grep -Eiv '^([01]|(true)|(false))$' > /dev/null ) ; then
+  cog verify "${VERIFY}" || exit 1
 fi


### PR DESCRIPTION
PR adds support for using cocogitto's [`verify`](https://docs.cocogitto.io/guide/#sandbox) functionality as part of a down-stream Action