### PR TITLE
fix: include lightweight tags in check

### DIFF
--- a/cog.sh
+++ b/cog.sh
@@ -17,8 +17,8 @@ git config --global user.email "$GIT_USER_EMAIL"
 
 if [ "$CHECK" = "true" ]; then
   if [ "$LATEST_TAG_ONLY" = "true" ]; then
-    if [ "$(git describe --abbrev=0)" ]; then
-      message="Checking commits from $(git describe --abbrev=0)"
+    if [ "$(git describe --tags --abbrev=0)" ]; then
+      message="Checking commits from $(git describe --tags --abbrev=0)"
     else
       message="No tag found checking history from first commit"
     fi


### PR DESCRIPTION
Many repositories use lightweight (non-annotated) tags. This patch
eliminates the scary warning that no tags were found, even if there were
tags available.

This makes the script match the behavior of `cog` itself (i.e., git
describe --tags --abbrev=0) [[1]].

[1]: https://github.com/cocogitto/cocogitto/blob/main/src/git/revspec.rs#L347-L357

Closes: #11
Signed-off-by: Luke Hsiao <luke.hsiao@numbersstation.ai>

---
