### PR TITLE
feat: update cocogitto to 6.0.1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 CUR_DIR=$(pwd)
-VERSION=5.6.0
+VERSION=6.0.1
 TAR="cocogitto-$VERSION-x86_64-unknown-linux-musl.tar.gz"
 BIN_DIR="$HOME/.local/bin"
 
 mkdir -p "$BIN_DIR"
 cd "$BIN_DIR" || exit
 curl -OL https://github.com/cocogitto/cocogitto/releases/download/"$VERSION"/"$TAR"
-tar xfz $TAR
+tar --strip-components=1 -xzf $TAR x86_64-unknown-linux-musl/cog
 cd "$CUR_DIR" || exit


### PR DESCRIPTION
Update the cocogitto dependency to [6.0.1](https://github.com/cocogitto/cocogitto/releases/tag/6.0.1).

This should fix #14 as well. I'm not sure if this should be flagged as a breaking change, because I couldn't find out if cocogitto v6 has breaking changes impacting users of this action.