### PR TITLE
Update cocogitto to 6.1.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CUR_DIR=$(pwd)
-VERSION=6.0.1
+VERSION=6.1.0
 TAR="cocogitto-$VERSION-x86_64-unknown-linux-musl.tar.gz"
 BIN_DIR="$HOME/.local/bin"
 


### PR DESCRIPTION
Updates the action to use the cocogitto [6.1.0](https://github.com/cocogitto/cocogitto/releases/tag/6.1.0)

Tested [here](https://github.com/nagyben/cog-example/actions/runs/8450509836)