### PR TITLE
fix: verify runs with blank text

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: cocogitto-action
+      - name: Initialise repository
+        run: |
+          git init
+          echo "# Mona Lisa" > README.md
+          git config --global user.name "Mona Lisa"
+          git config --global user.email "mona.lisa@example.com"
+          git add README.md
+          git commit -m "docs: add Mona Lisa docs"
+      - name: Run cocogitto-action
+        uses: ./cocogitto-action

--- a/cog.sh
+++ b/cog.sh
@@ -7,7 +7,7 @@ LATEST_TAG_ONLY="${2}"
 RELEASE="${3}"
 GIT_USER="${4}"
 GIT_USER_EMAIL="${5}"
-VERIFY="${7}"
+VERIFY="${6}"
 
 echo "Setting git user : ${GIT_USER}"
 git config --global user.name "${GIT_USER}"


### PR DESCRIPTION
It seems verify is always enabled and a blank text is verified. It always fails.

Also added a smoke test to ensure a new default parameter doesn't break the action.

Fixes #23
Caused by #10