### PR TITLE
feat: add ability to pass --ignore-merge-commits to cog check call

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Here are all the inputs available through `with`:
 | -------------------     | -------------------------------------------------------------------------- | -------    |
 | `check`                 | Check conventional commit compliance with `cog check`                      |   `true`   |
 | `check-latest-tag-only` | Check conventional commit compliance with `cog check --from-latest-tag`    |   `false`  |
+| `ignore-merge-commits`  | Ignore merge commits with `cog check --ignore-merge-commits`               |   `false`  |
 | `release`               | Perform a release using `cog bump --auto`                                  |   `false`  |
 | `git-user`              | Set the git `user.name` to use for the release commit                      |   `cog-bot`|
 | `git-user-email`        | Set the git `user.email` to use for the release commit                      |  `cog@demo.org`|

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Check commit history from latest tag to HEAD
     required: false
     default: 'false'
+  ignore-merge-commits:
+    description: Ignore merge commits when checking commit history
+    required: false
+    default: 'false'
   git-user:
     description: Git user.name configuration
     required: false
@@ -70,4 +74,5 @@ runs:
         ${{ inputs.release }}               \
         ${{ inputs.git-user }}              \
         ${{ inputs.git-user-email }}        \
-        ${{ inputs.verify }}
+        ${{ inputs.verify }}                \
+        ${{ inputs.ignore-merge-commits }}

--- a/cog.sh
+++ b/cog.sh
@@ -8,6 +8,7 @@ RELEASE="${3}"
 GIT_USER="${4}"
 GIT_USER_EMAIL="${5}"
 VERIFY="${6}"
+IGNORE_MERGE_COMMITs="${7}"
 
 echo "Setting git user : ${GIT_USER}"
 git config --global user.name "${GIT_USER}"
@@ -18,18 +19,22 @@ git config --global user.email "${GIT_USER_EMAIL}"
 cog --version
 
 if [ "${CHECK}" = "true" ]; then
+  flags=""
+  if [ "${IGNORE_MERGE_COMMITs}" = "true" ]; then
+    flags="$flags --ignore-merge-commits"
+  fi
   if [ "${LATEST_TAG_ONLY}" = "true" ]; then
+    flags="$flags --from-latest-tag"
     if [ "$(git describe --tags --abbrev=0)" ]; then
       message="Checking commits from $(git describe --tags --abbrev=0)"
     else
       message="No tag found checking history from first commit"
     fi
     echo "${message}"
-    cog check --from-latest-tag || exit 1
   else
     echo "Checking all commits"
-    cog check || exit 1
   fi
+  cog check $flags || exit 1
 fi
 
 if [ "${RELEASE}" = "true" ]; then


### PR DESCRIPTION
Allow specifying the `--ignore-merge-commits` as can be configured in a `cog.toml`.