### PR TITLE
Fix the problem with running in a container workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,3 +20,21 @@ jobs:
           git commit -m "docs: add Mona Lisa docs"
       - name: Run cocogitto-action
         uses: ./cocogitto-action
+  test-container:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/actions/actions-runner:latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: cocogitto-action
+      - name: Initialise repository
+        run: |
+          git init
+          echo "# Mona Lisa" > README.md
+          git config --global user.name "Mona Lisa"
+          git config --global user.email "mona.lisa@example.com"
+          git add README.md
+          git commit -m "docs: add Mona Lisa docs"
+      - name: Run cocogitto-action
+        uses: ./cocogitto-action

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
 
     - id: install
-      run: ${{ github.action_path }}/install.sh
+      run: ${GITHUB_ACTION_PATH}/install.sh
       shell: bash
 
     - run: echo Running cocogitto
@@ -76,7 +76,7 @@ runs:
     - id: cog
       shell: bash
       run: |
-        ${{ github.action_path }}/cog.sh \
+        ${GITHUB_ACTION_PATH}/cog.sh \
         "${{ inputs.check }}" \
         "${{ inputs.check-latest-tag-only }}" \
         "${{ inputs.release }}" \


### PR DESCRIPTION
cocogitto-action breaks when running in a container

This PR adds a container test (which will fail on main) and a fix

Assuming the container has git, curl and tar, (and is compatible with the architecture), cocogitto-action should work
on any debian based runner or container