### PR TITLE
fix: non-zero exit code hides command output

### DIFF
--- a/cog.sh
+++ b/cog.sh
@@ -22,13 +22,14 @@ fi
 
 echo "Running command: cog $COMMAND $ARGS"
 stdout="$(cog $COMMAND $ARGS 2>&1)"
-if [ $? -ne 0 ]; then
-  exit 1
-fi
-echo $stdout
-echo "stdout<<EOF" >> "$GITHUB_OUTPUT"
-echo "$stdout" >> "$GITHUB_OUTPUT"
-echo "EOF" >> "$GITHUB_OUTPUT"
+exit_code=$?
+{
+  echo "stdout<<EOF"
+  echo "$stdout"
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"
+echo "$stdout"
+[ $exit_code -ne 0 ] && exit $exit_code
 
 if [ "$COMMAND" = "release" ] || [ "$COMMAND" = "bump" ]; then
   VERSION="$(git describe --tags "$(git rev-list --tags --max-count=1)")"


### PR DESCRIPTION
This pull request does several things:

- fix a small typo in the echo setting git user email
- fix shellcheck SC2086 warning (double quote to prevent globbing and word splitting) on version output
- refactor exit code handling

This effectively fixes #48.

---

I’m not really sure as to what was intended by adding the command output to step outputs, but with this refactor:

- stdout is always added to outputs, whatever the exit code is
- command output is always output to stdout, whatever the exit code is
- script exits with original exit code when non-zero

I guess that with stdout being added to outputs, one could use it in the next step like this (untested):

```yaml
- if: always()
  uses: actions/github-script@v7
  with:
    github-token: ${{secrets.GITHUB_TOKEN}}
    script: |
      github.rest.issues.createComment({
        issue_number: context.issue.number,
        owner: context.repo.owner,
        repo: context.repo.repo,
        body: `Oh no! Cocogitto failed!
\`\`\`
${{ steps.cocogitto.outputs.stdout }}
\`\`\`
`
      })
```