### PR TITLE
fix: set git.user even on install only

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ runs:
       shell: bash
 
     - id: install
+      env:
+        GIT_USER: ${{ inputs.git-user }}
+        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
       run: ${GITHUB_ACTION_PATH}/install.sh
       shell: bash
 
@@ -62,7 +65,5 @@ runs:
       if: ${{ inputs.install-only != 'true' }}
       run: |
         ${GITHUB_ACTION_PATH}/cog.sh \
-        "${{ inputs.git-user }}" \
-        "${{ inputs.git-user-email }}" \
         "${{ inputs.command }}" \
         "${{ inputs.args }}"

--- a/cog.sh
+++ b/cog.sh
@@ -2,16 +2,9 @@
 
 set -a
 
-GIT_USER="${1}"
-GIT_USER_EMAIL="${2}"
-COMMAND="${3}"
-ARGS="${4}"
-
-echo "Setting git user : ${GIT_USER}"
-git config --global user.name "${GIT_USER}"
-
-echo "Setting git user email ${GIT_USER_EMAIL}"
-git config --global user.email "${GIT_USER_EMAIL}"
+COMMAND="${1}"
+shift
+ARGS="${*}"
 
 cog --version
 

--- a/install.sh
+++ b/install.sh
@@ -45,3 +45,13 @@ else
     tar --strip-components=1 -xzf $TAR "$ARCH-$PLATFORM/cog"
 fi
 cd "$CUR_DIR" || exit
+
+if ! git config --get user.name; then
+  echo "Setting git user : ${GIT_USER}"
+  git config --global user.name "${GIT_USER}"
+fi
+
+if ! git config --get user.email; then
+  echo "Setting git email : ${GIT_USER_EMAIL}"
+  git config --global user.email "${GIT_USER_EMAIL}"
+fi


### PR DESCRIPTION
Install-only doesn't run cog.sh, so subsequent cog commands can fail, due to
git.user.name and git.user.email not being set.

So we move the setting to install.sh.  
Also make the setting conditional, so that if there is already a valid git user set up, we don't override it.